### PR TITLE
Incidents page reports + bugfixes

### DIFF
--- a/backend/api/controllers/reportController.js
+++ b/backend/api/controllers/reportController.js
@@ -15,7 +15,7 @@ const parseQueryData = (queryString) => {
   if (!queryString) return {};
   // Data passed through URL parameters
   var query = _.pick(queryString, ['keywords', 'status', 'after', 'before', 'media',
-    'sourceId', 'groupId', 'author', 'tags', 'list', 'escalated', 'veracity', 'isRelevantReports',]);
+    'sourceId', 'groupId', 'author', 'tags', 'list', 'escalated', 'veracity', 'isRelevantReports', "irrelevant"]);
   if (query.tags) query.tags = tags.toArray(query.tags);
   return query;
 }
@@ -23,6 +23,7 @@ const parseQueryData = (queryString) => {
 // Get a list of queried Reports
 exports.report_reports = (req, res) => {
   // Parse query string
+
   const queryData = parseQueryData(req.query);
   if (queryData) {
     let query = new ReportQuery(queryData);

--- a/backend/models/group.js
+++ b/backend/models/group.js
@@ -214,6 +214,7 @@ Group.queryGroups = function (query, page, options, callback) {
   if (query.veracity === 'confirmed false') filter.veracity = 'Confirmed False';
   if (query.veracity === 'unconfirmed') filter.veracity = 'Unconfirmed';
 
+  // default filter open
   filter.closed = false;
   if (query.closed === 'all') delete filter.closed
   if (query.closed === 'true') filter.closed = true;

--- a/backend/models/query/report-query.js
+++ b/backend/models/query/report-query.js
@@ -29,6 +29,8 @@ function ReportQuery(options) {
   this.veracity = options.veracity;
   this.notes = options.notes;
   this.isRelevantReports = options.isRelevantReports;
+  this.irrelevant = options.irrelevant;
+
 }
 
 _.extend(ReportQuery, Query);
@@ -102,6 +104,10 @@ ReportQuery.prototype.toMongooseFilter = function () {
     //filter.$and.push(res)
   }
 
+  // default filter open
+  filter.irrelevant = "false";
+  if (this.irrelevant === 'all') delete filter.irrelevant
+  if (this.irrelevant === 'true') filter.irrelevant = "true";
   if (this.tags) {
     filter.smtcTags = { $all: this.tags };
   } else {

--- a/backend/models/query/report-query.js
+++ b/backend/models/query/report-query.js
@@ -105,9 +105,10 @@ ReportQuery.prototype.toMongooseFilter = function () {
   }
 
   // default filter open
-  filter.irrelevant = "false";
+  filter.irrelevant = { $in: ["false", "maybe"] };
   if (this.irrelevant === 'all') delete filter.irrelevant
   if (this.irrelevant === 'true') filter.irrelevant = "true";
+
   if (this.tags) {
     filter.smtcTags = { $all: this.tags };
   } else {

--- a/backend/models/report.js
+++ b/backend/models/report.js
@@ -33,7 +33,7 @@ let schema = new Schema({
   notes: { type: String },
   escalated: { type: Boolean, default: false, required: true, index: true },
   content_lang: { type: String },
-  irrelevant: { type: String, default: 'false', required: false, enum: ['false', 'true', 'maybe'] },
+  irrelevant: { type: String, default: 'maybe', required: false, enum: ['false', 'true', 'maybe'] },
   aitags: {
     type: Map,
     of: SchemaTypes.Mixed,

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -8,6 +8,7 @@ require('dotenv').config()
 var userSchema = new Schema({
   provider: { type: String, default: 'local' },
   username: { type: String, required: true, unique: true },
+  displayName: { type: String },
   email: { type: String, required: true, unique: true },
   password: { type: String },
   hasDefaultPassword: { type: Boolean, default: true },

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -164,7 +164,7 @@ const AppRouter = () => {
     variant: "primary",
   });
   const InitialApp = (
-    <div className='grid-rows-[auto_auto_1fr]'>
+    <div className='grid grid-rows-[auto_auto_1fr] h-[100svh]'>
       <div>
         <AggieNavbar isAuthenticated={isLoggedIn} session={userData} />
         <AlertService
@@ -173,12 +173,16 @@ const AppRouter = () => {
         />
       </div>
       <FetchIndicator className='sticky top-0 z-20 ' />
-
-      {isLoggedIn ? (
-        <PrivateRoutes sessionData={userData} setGlobalAlert={setGlobalAlert} />
-      ) : (
-        <PublicRoutes />
-      )}
+      <div className='h-full overflow-y-auto'>
+        {isLoggedIn ? (
+          <PrivateRoutes
+            sessionData={userData}
+            setGlobalAlert={setGlobalAlert}
+          />
+        ) : (
+          <PublicRoutes />
+        )}
+      </div>
     </div>
   );
 

--- a/src/api/groups/index.ts
+++ b/src/api/groups/index.ts
@@ -11,6 +11,8 @@ import {
 import type { Reports } from "../reports/types";
 import { hasId, VeracityOptions } from "../common";
 import { omitBy, isNil } from "lodash";
+import { ReportQueryState } from "../../objectTypes";
+import { urlFromReportsQuery } from "../reports";
 
 export const getGroups = async (
   searchState: GroupQueryState = {},
@@ -71,17 +73,15 @@ export const deleteGroup = async (group: Group) => {
   return data;
 };
 
-export const getGroupReports = async (
-  groupId: string | undefined,
-  page: number
-) => {
-  if (groupId) {
-    const { data } = await axios.get<Reports | undefined>(
-      "/api/report?groupId=" + groupId + "&page=" + page
-    );
-    return data;
-  }
+export const getGroupReports = async (searchState: ReportQueryState = {}) => {
+  if (!searchState.groupId) return undefined;
+  const queryState = urlFromReportsQuery(searchState);
+  const { data } = await axios.get<Reports | undefined>(
+    "/api/report?" + queryState
+  );
+  return data;
 };
+
 interface Selected {
   ids: string[];
 }
@@ -200,7 +200,7 @@ export const setSelectedLocationName = async (
  * @param queryState
  * @param tagIds
  */
-function urlFromQuery(queryState: GroupQueryState, tagIds: hasId[]) {
+function urlFromQuery(queryState: GroupQueryState, tagIds: hasId[] = []) {
   const url = new URLSearchParams();
   // i think ideally GroupQueryState should convert to record<string,string>
   Object.entries(queryState).forEach(([key, value]) => {

--- a/src/api/reports/types.ts
+++ b/src/api/reports/types.ts
@@ -55,6 +55,7 @@ export interface ReportQueryState {
   tagNames?: string[];
   page?: number;
   batch?: boolean;
+  irrelevant?: string;
 }
 
 // metadata typed

--- a/src/api/users/types.ts
+++ b/src/api/users/types.ts
@@ -9,11 +9,13 @@ export interface User extends hasId {
   role: UserRoles | string; // string for backwards compat
   email: string;
   username: string;
+  displayName?: string;
   __v: number;
 }
 
 export interface UserEditableData {
   username: string;
+  displayName?: string;
   email: string;
   role: UserRoles;
   _id?: string;

--- a/src/components/AggieToken.tsx
+++ b/src/components/AggieToken.tsx
@@ -7,6 +7,7 @@ const variants = {
   "light:red": "bg-red-200 text-red-800",
   "dark:red": "text-red-50 bg-red-600",
   "light:amber": "bg-amber-200 text-amber-800",
+  "light:green": "bg-green-200 text-green-800",
 };
 
 interface IProps {

--- a/src/components/MultiSelectListItem.tsx
+++ b/src/components/MultiSelectListItem.tsx
@@ -1,0 +1,62 @@
+import { faCheck } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import AggieCheck from "./AggieCheck";
+
+interface IProps {
+  children: React.ReactNode;
+  isChecked: boolean;
+  isSelectMode: boolean;
+  onCheckChange: () => void;
+  className?: string;
+}
+
+const MultiSelectListItem = ({
+  children,
+  isChecked,
+  isSelectMode,
+  onCheckChange,
+  className,
+}: IProps) => {
+  // refactor at some point
+  function bgState() {
+    if (isChecked && !isSelectMode)
+      return "border-2 border-slate-300 bg-slate-100 rounded-lg ";
+    else if (isChecked && isSelectMode) return "bg-blue-100 ";
+    return "bg-white hover:bg-slate-100";
+  }
+  function onChange(e: React.MouseEvent<HTMLDivElement>) {
+    e.stopPropagation();
+    onCheckChange();
+  }
+  const customClass =
+    className ||
+    `px-2 py-2 pl-8 pb-4 border-b border-slate-300 ${bgState()} relative group`;
+  return (
+    <article className={customClass}>
+      {isSelectMode ? (
+        <div
+          className='flex items-center absolute top-0 bottom-0 left-0 w-12 pointer-events-none '
+          onClick={onChange}
+        >
+          <div className='w-full h-full pointer-events-auto cursor-pointer group hover:bg-blue-200/25 rounded p-2 pl-3 '>
+            <div
+              className={`w-4 h-4  border border-slate-500  group-hover:border-slate-600 grid place-items-center rounded ${
+                isChecked ? "bg-blue-500 text-slate-50" : "bg-white"
+              }`}
+            >
+              {isChecked && <FontAwesomeIcon icon={faCheck} size='xs' />}
+            </div>
+          </div>
+          <div className='absolute ml-8 pointer-events-none h-full my-3 border-r border-slate-300'></div>
+        </div>
+      ) : (
+        <div className='opacity-0 group-hover:opacity-100 flex items-center absolute top-0 left-0 pointer-events-none p-2 pl-3 '>
+          <AggieCheck active={isChecked} onClick={onChange} />
+        </div>
+      )}
+      {children}
+    </article>
+  );
+};
+
+export default MultiSelectListItem;

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,6 +1,7 @@
 import { Popover } from "@headlessui/react";
 import { Formik, Field, Form } from "formik";
 import AggieButton from "./AggieButton";
+import { usePopover } from "../hooks/usePopover";
 
 import {
   faAngleDoubleLeft,
@@ -25,6 +26,9 @@ const Pagination = ({
   size = 3,
   pageSize = 50,
 }: IPagination) => {
+  const { isOpen, refs, getReferenceProps, getFloatingProps, floatingStyles } =
+    usePopover();
+
   const totalPages = totalCount ? Math.floor(totalCount / pageSize) : 0;
 
   // light logic wrapper for whether or not to display buttons
@@ -69,59 +73,69 @@ const Pagination = ({
           />
         ))}
 
-      <Popover className='relative'>
-        <Popover.Button className='focus-theme px-2 py-2 hover:bg-slate-200 whitespace-nowrap'>
+      <div className='relative'>
+        <button
+          ref={refs.setReference}
+          className='focus-theme px-2 py-2 hover:bg-slate-200 whitespace-nowrap'
+          {...getReferenceProps()}
+        >
           Page {currentPage + 1}{" "}
           {totalCount !== 0 && <span>of {totalPages || 1}</span>}
-        </Popover.Button>
-
-        <Popover.Panel className='absolute top-full mt-1 z-10 p-2 bg-white rounded-lg shadow-md border border-slate-300'>
-          <Formik
-            initialValues={{ page: undefined }}
-            onSubmit={(e) => e.page && onPageChange(e.page)}
+        </button>
+        {isOpen && (
+          <div
+            ref={refs.setFloating}
+            style={floatingStyles}
+            className='absolute top-full mt-1 z-10 p-2 bg-white rounded-lg shadow-md border border-slate-300'
+            {...getFloatingProps()}
           >
-            <Form className=''>
-              <label className='mb-1'>Jump to:</label>
-              <div className='flex focus-within-theme rounded-lg'>
-                <Field
-                  name='page'
-                  type='number'
-                  autoFocus
-                  className='focus-theme px-2 py-2 border border-r-0 border-slate-300 bg-slate-50 rounded-l-lg w-24'
-                  placeholder='page #'
-                  max={totalPages}
-                />
-                <AggieButton
-                  type='submit'
-                  className='px-2 py-1 bg-slate-50 hover:bg-white rounded-r-lg border-y border-r border-slate-30'
-                >
-                  <FontAwesomeIcon icon={faArrowRight} />
-                </AggieButton>
-              </div>
-            </Form>
-          </Formik>
-          <div className='flex gap-1 mt-1'>
-            <AggieButton
-              variant='secondary'
-              onClick={() => onPageChange(0)}
-              disabled={currentPage === 0}
-              className='w-full'
+            <Formik
+              initialValues={{ page: currentPage + 1 }}
+              onSubmit={(e) => onPageChange(e.page - 1)}
             >
-              <FontAwesomeIcon icon={faAngleDoubleLeft} />
-              First
-            </AggieButton>
-            <AggieButton
-              variant='secondary'
-              onClick={() => onPageChange(totalPages)}
-              disabled={currentPage === totalPages}
-              className='w-full'
-            >
-              Last
-              <FontAwesomeIcon icon={faAngleDoubleRight} />
-            </AggieButton>
+              <Form className=''>
+                <label className='mb-1'>Jump to:</label>
+                <div className='flex focus-within-theme rounded-lg'>
+                  <Field
+                    name='page'
+                    type='number'
+                    autoFocus
+                    className='focus-theme px-2 py-2 border border-r-0 border-slate-300 bg-slate-50 rounded-l-lg w-24'
+                    placeholder='page #'
+                    max={totalPages}
+                  />
+                  <AggieButton
+                    type='submit'
+                    className='px-2 py-1 bg-slate-50 hover:bg-white rounded-r-lg border-y border-r border-slate-30'
+                  >
+                    <FontAwesomeIcon icon={faArrowRight} />
+                  </AggieButton>
+                </div>
+              </Form>
+            </Formik>
+            <div className='flex gap-1 mt-1'>
+              <AggieButton
+                variant='secondary'
+                onClick={() => onPageChange(0)}
+                disabled={currentPage === 0}
+                className='w-full'
+              >
+                <FontAwesomeIcon icon={faAngleDoubleLeft} />
+                First
+              </AggieButton>
+              <AggieButton
+                variant='secondary'
+                onClick={() => onPageChange(totalPages - 1)}
+                disabled={currentPage === totalPages}
+                className='w-full'
+              >
+                Last
+                <FontAwesomeIcon icon={faAngleDoubleRight} />
+              </AggieButton>
+            </div>
           </div>
-        </Popover.Panel>
-      </Popover>
+        )}
+      </div>
 
       {Array(size)
         .fill(0)

--- a/src/components/SocialMediaListItem/index.tsx
+++ b/src/components/SocialMediaListItem/index.tsx
@@ -1,0 +1,102 @@
+import {
+  faXmark,
+  faExclamationTriangle,
+  faRetweet,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Report } from "../../api/reports/types";
+import { formatText } from "../../utils/format";
+import AggieToken from "../AggieToken";
+import DateTime from "../DateTime";
+import GeneratedTagsList from "../GeneratedTagsList";
+import { parseContentType, sanitize } from "../SocialMediaPost/reportParser";
+import SocialMediaIcon from "../SocialMediaPost/SocialMediaIcon";
+import { parseYoutube } from "../SocialMediaPost/YoutubePost";
+import TagsList from "../Tags/TagsList";
+interface IProps {
+  report: Report;
+  header?: React.ReactNode;
+}
+
+const SocialMediaListItem = ({ report, header }: IProps) => {
+  const contentType = parseContentType(report);
+
+  function renderText(type: typeof contentType) {
+    switch (type) {
+      case "twitter:quoteRetweet":
+      case "twitter:retweet":
+        return (
+          <>
+            <div className='grid place-items-center'>
+              <FontAwesomeIcon icon={faRetweet} />
+            </div>
+            <p className=' text-black max-h-[10em] line-clamp-4'>
+              {formatText(report.content)}
+            </p>
+          </>
+        );
+      case "truthsocial":
+        return (
+          <p
+            className='truthsocial text-black'
+            dangerouslySetInnerHTML={{
+              __html: sanitize(report.content),
+            }}
+          ></p>
+        );
+      case "youtube":
+        const { title, description } = parseYoutube(report);
+        return (
+          <p className=' text-black max-h-[10em] line-clamp-4'>
+            <span className=''>{title} </span>
+          </p>
+        );
+      default:
+        return (
+          <p className=' text-black max-h-[10em] line-clamp-4'>
+            {formatText(report.content)}
+          </p>
+        );
+    }
+  }
+
+  return (
+    <>
+      <header className='flex justify-between mb-2 relative'>
+        <div className='flex flex-wrap gap-1 text-sm items-baseline max-w-[43em]'>
+          <h1 className={`text-sm text-black mx-1 font-medium `}>
+            <span className='mr-2 text-slate-600 text-xs'>
+              <SocialMediaIcon mediaKey={report._media[0]} />
+            </span>
+            {report.author}
+          </h1>
+
+          {report.irrelevant && report.irrelevant === "true" && (
+            <AggieToken variant='light:red' icon={faXmark} className='text-xs'>
+              Irrelevant
+            </AggieToken>
+          )}
+          {report.red_flag && (
+            <AggieToken
+              variant='dark:red'
+              icon={faExclamationTriangle}
+              className='text-xs'
+            >
+              Red Flag
+            </AggieToken>
+          )}
+          <GeneratedTagsList tags={report.aitags} />
+          <TagsList values={report.smtcTags} />
+        </div>
+        {header || (
+          <div className='text-xs '>
+            <DateTime dateString={report.authoredAt} />
+          </div>
+        )}
+      </header>
+      <div className='flex gap-2'>{renderText(contentType)}</div>
+    </>
+  );
+};
+
+export default SocialMediaListItem;

--- a/src/components/SocialMediaListItem/index.tsx
+++ b/src/components/SocialMediaListItem/index.tsx
@@ -11,6 +11,7 @@ import DateTime from "../DateTime";
 import GeneratedTagsList from "../GeneratedTagsList";
 import { parseContentType, sanitize } from "../SocialMediaPost/reportParser";
 import SocialMediaIcon from "../SocialMediaPost/SocialMediaIcon";
+import { parseQuoteRetweet } from "../SocialMediaPost/TwitterPost";
 import { parseYoutube } from "../SocialMediaPost/YoutubePost";
 import TagsList from "../Tags/TagsList";
 interface IProps {
@@ -22,8 +23,10 @@ const SocialMediaListItem = ({ report, header }: IProps) => {
   const contentType = parseContentType(report);
 
   function renderText(type: typeof contentType) {
+    if (report.author.includes("Thomas")) console.log(report.author, type);
     switch (type) {
       case "twitter:quoteRetweet":
+
       case "twitter:retweet":
         return (
           <>
@@ -35,10 +38,30 @@ const SocialMediaListItem = ({ report, header }: IProps) => {
             </p>
           </>
         );
+      case "twitter:quote":
+        const rawPostData = (report.metadata.rawAPIResponse.attributes as any)
+          ?.post_data;
+        const data = parseQuoteRetweet(rawPostData);
+
+        return (
+          <>
+            <div className=' max-h-[10em] text-black'>
+              <p className='text-black line-clamp-2 mb-1'>
+                {formatText(report.content)}
+              </p>
+
+              <div className='border border-slate-300 rounded-lg py-2 px-3 '>
+                <p className='font-medium text-sm'>{data.author?.name}</p>
+                <p className='line-clamp-2'>{formatText(data.content)}</p>
+              </div>
+            </div>
+          </>
+        );
+
       case "truthsocial":
         return (
           <p
-            className='truthsocial text-black'
+            className='truthsocial text-black line-clamp-4'
             dangerouslySetInnerHTML={{
               __html: sanitize(report.content),
             }}
@@ -94,7 +117,7 @@ const SocialMediaListItem = ({ report, header }: IProps) => {
           </div>
         )}
       </header>
-      <div className='flex gap-2'>{renderText(contentType)}</div>
+      <div className='flex gap-2 max-w-prose'>{renderText(contentType)}</div>
     </>
   );
 };

--- a/src/components/SocialMediaListItem/index.tsx
+++ b/src/components/SocialMediaListItem/index.tsx
@@ -23,14 +23,39 @@ const SocialMediaListItem = ({ report, header }: IProps) => {
   const contentType = parseContentType(report);
 
   function renderText(type: typeof contentType) {
-    if (report.author.includes("Thomas")) console.log(report.author, type);
     switch (type) {
-      case "twitter:quoteRetweet":
+      case "twitter:quoteRetweet": {
+        const rawPostData = (report.metadata.rawAPIResponse.attributes as any)
+          ?.post_data;
+        const data = parseQuoteRetweet(rawPostData);
 
+        return (
+          <>
+            <div className='grid place-items-center text-slate-600'>
+              <FontAwesomeIcon icon={faRetweet} />
+            </div>
+            <div className=' max-h-[10em] text-black'>
+              <p className='font-medium text-sm'>{data.author?.name}</p>
+              <p className='text-black line-clamp-2 mb-1'>
+                {formatText(data.content)}
+              </p>
+
+              <div className='border border-slate-300 rounded-lg py-2 px-3 '>
+                <p className='font-medium text-sm'>
+                  {data.innerPost.author?.name}
+                </p>
+                <p className='line-clamp-2'>
+                  {formatText(data.innerPost.content)}
+                </p>
+              </div>
+            </div>
+          </>
+        );
+      }
       case "twitter:retweet":
         return (
           <>
-            <div className='grid place-items-center'>
+            <div className='grid place-items-center text-slate-600'>
               <FontAwesomeIcon icon={faRetweet} />
             </div>
             <p className=' text-black max-h-[10em] line-clamp-4'>
@@ -38,7 +63,7 @@ const SocialMediaListItem = ({ report, header }: IProps) => {
             </p>
           </>
         );
-      case "twitter:quote":
+      case "twitter:quote": {
         const rawPostData = (report.metadata.rawAPIResponse.attributes as any)
           ?.post_data;
         const data = parseQuoteRetweet(rawPostData);
@@ -57,7 +82,7 @@ const SocialMediaListItem = ({ report, header }: IProps) => {
             </div>
           </>
         );
-
+      }
       case "truthsocial":
         return (
           <p

--- a/src/components/SocialMediaListItem/index.tsx
+++ b/src/components/SocialMediaListItem/index.tsx
@@ -2,6 +2,7 @@ import {
   faXmark,
   faExclamationTriangle,
   faRetweet,
+  faDotCircle,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Report } from "../../api/reports/types";
@@ -17,9 +18,10 @@ import TagsList from "../Tags/TagsList";
 interface IProps {
   report: Report;
   header?: React.ReactNode;
+  headerClassName?: string;
 }
 
-const SocialMediaListItem = ({ report, header }: IProps) => {
+const SocialMediaListItem = ({ report, header, headerClassName }: IProps) => {
   const contentType = parseContentType(report);
 
   function renderText(type: typeof contentType) {
@@ -111,7 +113,9 @@ const SocialMediaListItem = ({ report, header }: IProps) => {
   return (
     <>
       <header className='flex justify-between mb-2 relative'>
-        <div className='flex flex-wrap gap-1 text-sm items-baseline max-w-[43em]'>
+        <div
+          className={`flex flex-wrap gap-1 text-sm items-baseline ${headerClassName}`}
+        >
           <h1 className={`text-sm text-black mx-1 font-medium `}>
             <span className='mr-2 text-slate-600 text-xs'>
               <SocialMediaIcon mediaKey={report._media[0]} />
@@ -122,6 +126,15 @@ const SocialMediaListItem = ({ report, header }: IProps) => {
           {report.irrelevant && report.irrelevant === "true" && (
             <AggieToken variant='light:red' icon={faXmark} className='text-xs'>
               Irrelevant
+            </AggieToken>
+          )}
+          {report.irrelevant && report.irrelevant === "false" && (
+            <AggieToken
+              variant='light:green'
+              icon={faDotCircle}
+              className='text-xs'
+            >
+              Relevant
             </AggieToken>
           )}
           {report.red_flag && (

--- a/src/components/SocialMediaPost/PostListItem.tsx
+++ b/src/components/SocialMediaPost/PostListItem.tsx
@@ -1,5 +1,0 @@
-const PostListItem = () => {
-  return <></>;
-};
-
-export default PostListItem;

--- a/src/components/SocialMediaPost/TwitterPost.tsx
+++ b/src/components/SocialMediaPost/TwitterPost.tsx
@@ -174,7 +174,7 @@ function parseTwitterUser(rawPostData: any) {
   };
 }
 
-function parseQuoteRetweet(post_data: any) {
+export function parseQuoteRetweet(post_data: any) {
   const retweetResult = post_data?.retweeted_status_result?.result;
   const quotedResult = post_data?.api_data?.quoted_status_result?.result;
   const result = retweetResult || quotedResult;

--- a/src/components/SocialMediaPost/index.tsx
+++ b/src/components/SocialMediaPost/index.tsx
@@ -40,7 +40,6 @@ const SocialMediaPost = ({ report, showMedia }: IProps) => {
       </div>
     );
   };
-  console.log(report);
   return (
     <div className='pb-2 px-3 pt-3 bg-white rounded-xl border border-slate-300 text-base '>
       {report._media[0] === "twitter" && <TwitterReply report={report} />}

--- a/src/components/SocialMediaPost/index.tsx
+++ b/src/components/SocialMediaPost/index.tsx
@@ -14,6 +14,7 @@ import TwitterPost from "./TwitterPost";
 import YoutubePost from "./YoutubePost";
 import SocialMediaAuthor from "./SocialMediaAuthor";
 import TruthSocialPost from "./TruthSocialPost";
+import SocialMediaIcon from "./SocialMediaIcon";
 
 interface IProps {
   report: Report;
@@ -52,7 +53,7 @@ const SocialMediaPost = ({ report, showMedia }: IProps) => {
             url={report.metadata.accountUrl}
           />
         </div>
-        <p className='flex flex-col items-end gap-1'>
+        <p className='flex items-center gap-2 h-fit pr-1'>
           <a
             target='_blank'
             href={report.url}
@@ -61,6 +62,9 @@ const SocialMediaPost = ({ report, showMedia }: IProps) => {
             <span>Open Post</span>
             <FontAwesomeIcon icon={faExternalLink} />
           </a>
+          <div className='text-slate-600'>
+            <SocialMediaIcon mediaKey={report._media[0]} />
+          </div>
         </p>
       </div>
 

--- a/src/components/UserToken.tsx
+++ b/src/components/UserToken.tsx
@@ -36,13 +36,18 @@ const UserToken = ({ id, className = "", disabled, loading }: IProps) => {
       </span>
     );
   if (disabled)
-    return <span className={`${className}`}> {user?.username}</span>;
+    return (
+      <span className={`${className}`}>
+        {" "}
+        {user?.displayName || user?.username}
+      </span>
+    );
   return (
     <Link
       to={"/settings/user/" + user?._id}
       className={`text-blue-600 hover:underline hover:bg-slate-200 ${className}`}
     >
-      {user?.username}
+      {user?.displayName || user?.username}
     </Link>
   );
 };

--- a/src/hooks/usePopover.ts
+++ b/src/hooks/usePopover.ts
@@ -5,6 +5,7 @@ import {
   useFocus,
   safePolygon,
   flip,
+  shift,
   offset,
 } from "@floating-ui/react";
 import { useState } from "react";
@@ -23,10 +24,8 @@ export function usePopover(
   const [isOpen, setIsOpen] = useState(false);
 
   const { refs, floatingStyles, context } = useFloating({
-    middleware: [
-      flip({ fallbackAxisSideDirection: "start" }),
-      offset(options.offset),
-    ],
+    placement: "bottom",
+    middleware: [flip(), shift(), offset(options.offset)],
 
     open: isOpen,
     onOpenChange: setIsOpen,

--- a/src/pages/Reports/AllReportsList.tsx
+++ b/src/pages/Reports/AllReportsList.tsx
@@ -28,7 +28,6 @@ const AllReportsList = ({}: IProps) => {
   const reportsQuery = useQuery(["reports"], () => getReports(getAllParams()), {
     refetchInterval: 120000,
   });
-  const { status: reportsStatus } = reportsQuery;
   useEffect(() => {
     // refetch on filter change
     reportsQuery.refetch();
@@ -60,13 +59,23 @@ const AllReportsList = ({}: IProps) => {
         <ReportsFilters
           reportCount={reportsQuery.data && reportsQuery.data.total}
           headerElement={
-            <AggieButton
-              variant='secondary'
-              className='text-xs font-medium '
-              onClick={() => multiSelect.toggleActive()}
-            >
-              {multiSelect.isActive ? "Cancel Selection" : "Select Multiple"}
-            </AggieButton>
+            multiSelect.isActive ? (
+              <AggieButton
+                variant='secondary'
+                className='text-xs font-medium '
+                onClick={() => multiSelect.toggleActive()}
+              >
+                Cancel Selection
+              </AggieButton>
+            ) : (
+              <AggieCheck
+                active={multiSelect.isActive}
+                onClick={() => {
+                  multiSelect.toggleActive();
+                  multiSelect.addRemoveAll(reportsQuery.data?.results);
+                }}
+              />
+            )
           }
         />
         <div

--- a/src/pages/Reports/AllReportsList.tsx
+++ b/src/pages/Reports/AllReportsList.tsx
@@ -118,9 +118,9 @@ const AllReportsList = ({}: IProps) => {
             >
               <ReportListItem
                 report={report}
-                isChecked={multiSelect.exists(report._id)}
+                isChecked={multiSelect.exists(report)}
                 isSelectMode={multiSelect.isActive}
-                onCheckChange={() => multiSelect.addRemove(report._id)}
+                onCheckChange={() => multiSelect.addRemove(report)}
               />
             </div>
           ))

--- a/src/pages/Reports/AllReportsList.tsx
+++ b/src/pages/Reports/AllReportsList.tsx
@@ -106,7 +106,7 @@ const AllReportsList = ({}: IProps) => {
         </div>
       </div>
 
-      <div className='flex flex-col border border-slate-300 rounded-lg'>
+      <div className='flex flex-col border border-slate-300 rounded-lg bg-white'>
         {!!reportsQuery.data?.results && reportsQuery.data?.total > 0 ? (
           reportsQuery.data?.results.map((report) => (
             <div

--- a/src/pages/Reports/AllReportsList.tsx
+++ b/src/pages/Reports/AllReportsList.tsx
@@ -16,6 +16,8 @@ import AggieButton from "../../components/AggieButton";
 
 import { faMinus } from "@fortawesome/free-solid-svg-icons";
 import MultiSelectActions from "./components/MultiSelectActions";
+import { report } from "process";
+import AddReportsToIncidents from "./components/AddReportsToIncident";
 
 interface IProps {}
 
@@ -100,6 +102,7 @@ const AllReportsList = ({}: IProps) => {
                 selection={multiSelect.selection}
                 disabled={!multiSelect.any()}
                 currentPageId={currentPageId}
+                addRemoveSelection={multiSelect.addRemove}
               />
             </>
           )}

--- a/src/pages/Reports/BatchReportsList.tsx
+++ b/src/pages/Reports/BatchReportsList.tsx
@@ -163,9 +163,9 @@ const BatchReportList = ({}: IProps) => {
             >
               <ReportListItem
                 report={report}
-                isChecked={multiSelect.exists(report._id)}
+                isChecked={multiSelect.exists(report)}
                 isSelectMode={multiSelect.isActive}
-                onCheckChange={() => multiSelect.addRemove(report._id)}
+                onCheckChange={() => multiSelect.addRemove(report)}
               />
             </div>
           ))}

--- a/src/pages/Reports/BatchReportsList.tsx
+++ b/src/pages/Reports/BatchReportsList.tsx
@@ -151,7 +151,7 @@ const BatchReportList = ({}: IProps) => {
           )}
         </div>
       </div>
-      <div className='flex flex-col border border-slate-200 rounded-lg'>
+      <div className='flex flex-col border border-slate-200 rounded-lg bg-white'>
         {batchData &&
           batchData.results.map((report) => (
             <div

--- a/src/pages/Reports/BatchReportsList.tsx
+++ b/src/pages/Reports/BatchReportsList.tsx
@@ -145,6 +145,7 @@ const BatchReportList = ({}: IProps) => {
                 queryKey={["batch"]}
                 selection={multiSelect.selection}
                 disabled={!multiSelect.any()}
+                addRemoveSelection={multiSelect.addRemove}
                 currentPageId={currentPageId}
               />
             </>

--- a/src/pages/Reports/FlaggedReportsList.tsx
+++ b/src/pages/Reports/FlaggedReportsList.tsx
@@ -111,9 +111,9 @@ const FlaggedReportsList = ({}: IProps) => {
             >
               <ReportListItem
                 report={report}
-                isChecked={multiSelect.exists(report._id)}
+                isChecked={multiSelect.exists(report)}
                 isSelectMode={multiSelect.isActive}
-                onCheckChange={() => multiSelect.addRemove(report._id)}
+                onCheckChange={() => multiSelect.addRemove(report)}
               />
             </div>
           ))

--- a/src/pages/Reports/FlaggedReportsList.tsx
+++ b/src/pages/Reports/FlaggedReportsList.tsx
@@ -93,6 +93,7 @@ const FlaggedReportsList = ({}: IProps) => {
                 selection={multiSelect.selection}
                 disabled={!multiSelect.any()}
                 currentPageId={currentPageId}
+                addRemoveSelection={multiSelect.addRemove}
               />
             </>
           )}

--- a/src/pages/Reports/Report/index.tsx
+++ b/src/pages/Reports/Report/index.tsx
@@ -119,7 +119,7 @@ const Report = () => {
   return (
     <article className='pt-4 pr-2 sticky top-0 overflow-y-auto min-h-[70vh] max-h-[93vh]  '>
       <AddReportsToIncidents
-        selection={id ? [id] : undefined}
+        selection={report ? [report] : undefined}
         isOpen={addReportModal}
         queryKey={["reports"]}
         onClose={() => setAddReportModal(false)}

--- a/src/pages/Reports/Report/index.tsx
+++ b/src/pages/Reports/Report/index.tsx
@@ -125,46 +125,61 @@ const Report = () => {
         onClose={() => setAddReportModal(false)}
         addRemove={() => setAddReportModal(false)}
       />
-      <nav className='pl-3 pr-2 py-2 flex justify-between items-center rounded-lg text-xs border border-slate-300 mb-2 shadow-md bg-white'>
+      <nav className='sticky top-0 pl-3 pr-2 py-2 flex justify-between items-center rounded-lg text-xs border border-slate-300 mb-2 shadow-md bg-white'>
         <div className='flex   '>Actions</div>
         <div className='flex gap-1'>
-          <div className='flex text-xs  rounded-lg border border-slate-300'>
+          <AggieButton
+            variant={report.read ? "light:lime" : "light:amber"}
+            className='rounded-lg border border-slate-300 '
+            onClick={(e) => {
+              e.stopPropagation();
+
+              setRead.mutate({
+                reportIds: [report._id],
+                read: !report.read,
+                currentPageId: report._id,
+              });
+            }}
+            loading={setRead.isLoading}
+            disabled={!report || setRead.isLoading}
+            icon={report.read ? faEnvelopeOpen : faEnvelope}
+          >
+            {report.read ? <> unread</> : <> read</>}
+          </AggieButton>
+          <div className='rounded-lg border border-slate-300 '>
             <AggieButton
-              variant={report.read ? "light:lime" : "light:amber"}
+              variant={"light:rose"}
               className='rounded-l-lg'
               onClick={(e) => {
                 e.stopPropagation();
-
-                setRead.mutate({
+                setIrrelevance.mutate({
                   reportIds: [report._id],
-                  read: !report.read,
-                  currentPageId: id,
+                  irrelevant: "true",
+                  currentPageId: report._id,
                 });
               }}
-              loading={setRead.isLoading}
-              disabled={!report || setRead.isLoading}
-              icon={report.read ? faEnvelopeOpen : faEnvelope}
+              icon={faXmark}
+              loading={setIrrelevance.isLoading}
+              disabled={!report || setIrrelevance.isLoading}
             >
-              {report.read ? <> unread</> : <> read</>}
+              irrelevant
             </AggieButton>
             <AggieButton
-              variant={
-                report.irrelevant === "true" ? "light:green" : "light:rose"
-              }
+              variant={"light:green"}
               className='rounded-r-lg'
               onClick={(e) => {
                 e.stopPropagation();
                 setIrrelevance.mutate({
                   reportIds: [report._id],
-                  irrelevant: report.irrelevant === "true" ? "false" : "true",
-                  currentPageId: id,
+                  irrelevant: "false",
+                  currentPageId: report._id,
                 });
               }}
-              icon={report.irrelevant === "true" ? faDotCircle : faXmark}
+              icon={faDotCircle}
               loading={setIrrelevance.isLoading}
               disabled={!report || setIrrelevance.isLoading}
             >
-              {report.irrelevant === "true" ? <>relevant</> : <>irrelevant</>}
+              relevant
             </AggieButton>
           </div>
 

--- a/src/pages/Reports/Report/index.tsx
+++ b/src/pages/Reports/Report/index.tsx
@@ -123,6 +123,7 @@ const Report = () => {
         isOpen={addReportModal}
         queryKey={["reports"]}
         onClose={() => setAddReportModal(false)}
+        addRemove={() => setAddReportModal(false)}
       />
       <nav className='pl-3 pr-2 py-2 flex justify-between items-center rounded-lg text-xs border border-slate-300 mb-2 shadow-md bg-white'>
         <div className='flex   '>Actions</div>

--- a/src/pages/Reports/components/AddReportsToIncident.tsx
+++ b/src/pages/Reports/components/AddReportsToIncident.tsx
@@ -16,6 +16,11 @@ import SocialMediaPost from "../../../components/SocialMediaPost";
 
 import NestedIncidentsList from "./NestedIncidentsList";
 import IncidentsFilters from "../../incidents/IncidentsFilters";
+import MultiSelectListItem from "../../../components/MultiSelectListItem";
+import SocialMediaListItem from "../../../components/SocialMediaListItem";
+import { useMultiSelect } from "../../../hooks/useMultiSelect";
+import AggieCheck from "../../../components/AggieCheck";
+import { faMinus } from "@fortawesome/free-solid-svg-icons";
 
 interface IAddReportsToIncidents {
   isOpen: boolean;
@@ -44,20 +49,9 @@ const AddReportsToIncidents = ({
     clearAllParams,
   } = useQueryParamsInternal<GroupQueryState>();
 
-  // function ReportsFromSelection(
-  //   ids: string[] | undefined,
-  //   openStatus: boolean
-  // ) {
-  //   // dont run if window not open
-  //   if (!openStatus) return [];
-  //   if (!ids || ids.length === 0) return [];
-  //   const data = queryClient.getQueryData<Reports>(queryKey);
-  //   //TODO: nice error window
-  //   if (!data) return [];
-  //   const getReports = data?.results.filter((i) => ids.includes(i._id));
-  //   if (!getReports) return [];
-  //   return getReports;
-  // }
+  const multiSelect = useMultiSelect({
+    allItems: selection,
+  });
 
   const { data: incidents, refetch } = useQuery({
     queryKey: ["groups"],
@@ -100,7 +94,7 @@ const AddReportsToIncidents = ({
     <Dialog open={isOpen} onClose={onClose} className='relative z-50'>
       <div className='fixed inset-0 bg-black/30' aria-hidden='true' />
       <div className='fixed inset-0 flex w-screen items-center justify-center p-4'>
-        <Dialog.Panel className='bg-gray-50 rounded-xl border border-slate-200 shadow-xl min-w-24 h-[90vh] min-h-12 p-3 grid grid-cols-2 gap-2 w-full	grid-rows-[auto_1fr]'>
+        <Dialog.Panel className='bg-gray-50 rounded-xl border border-slate-200 shadow-xl min-w-24 h-[90vh] min-h-12 p-3 grid grid-cols-2 gap-y-1 gap-x-4 w-full	grid-rows-[auto_1fr]'>
           <div className='col-span-2 flex justify-between '>
             <div className='flex-1'>
               <AggieButton variant='secondary' onClick={onClose}>
@@ -124,11 +118,50 @@ const AddReportsToIncidents = ({
 
           <div className='overflow-y-auto flex flex-col gap-1 h-full'>
             <h2 className='font-medium text-lg mb-1'>Selected Reports:</h2>
+            <div className='flex gap-1 items-center'>
+              <AggieCheck
+                active={multiSelect.isActive}
+                icon={!multiSelect.all() ? faMinus : undefined}
+                onClick={() => {
+                  if (multiSelect.isActive && multiSelect.any()) {
+                    multiSelect.setActive(false);
+                    multiSelect.set([]);
+                  } else if (!multiSelect.isActive && !multiSelect.any()) {
+                    multiSelect.setActive(true);
+                    multiSelect.addRemoveAll(selection);
+                  } else {
+                    multiSelect.addRemoveAll(selection);
+                  }
+                }}
+              />
 
-            {selection &&
-              selection.map((report) => (
-                <SocialMediaPost key={report._id} report={report} />
-              ))}
+              {multiSelect.isActive && (
+                <>
+                  <AggieButton
+                    variant='secondary'
+                    className='text-xs font-medium '
+                    onClick={() => multiSelect.toggleActive()}
+                  >
+                    Cancel Selection
+                  </AggieButton>
+                </>
+              )}
+            </div>
+            <div className='rounded-lg border overflow-x-hidden border-slate-300 overflow-y-auto'>
+              {selection &&
+                selection.map((report) => (
+                  <MultiSelectListItem
+                    isChecked={multiSelect.exists(report)}
+                    isSelectMode={multiSelect.isActive}
+                    onCheckChange={() => multiSelect.addRemove(report)}
+                    key={report._id}
+                  >
+                    <div className='text-sm'>
+                      <SocialMediaListItem report={report} />
+                    </div>
+                  </MultiSelectListItem>
+                ))}
+            </div>
           </div>
 
           <div className='flex flex-col h-full overflow-y-auto'>

--- a/src/pages/Reports/components/AddReportsToIncident.tsx
+++ b/src/pages/Reports/components/AddReportsToIncident.tsx
@@ -20,7 +20,7 @@ import MultiSelectListItem from "../../../components/MultiSelectListItem";
 import SocialMediaListItem from "../../../components/SocialMediaListItem";
 import { useMultiSelect } from "../../../hooks/useMultiSelect";
 import AggieCheck from "../../../components/AggieCheck";
-import { faMinus } from "@fortawesome/free-solid-svg-icons";
+import { faMinus, faMinusCircle } from "@fortawesome/free-solid-svg-icons";
 
 interface IAddReportsToIncidents {
   isOpen: boolean;
@@ -28,6 +28,7 @@ interface IAddReportsToIncidents {
   queryKey: any[];
   onSuccess?: () => void;
   onClose: () => void;
+  addRemove: (r: Report) => void;
 }
 const AddReportsToIncidents = ({
   isOpen,
@@ -35,6 +36,7 @@ const AddReportsToIncidents = ({
   queryKey,
   onClose,
   onSuccess,
+  addRemove,
 }: IAddReportsToIncidents) => {
   const [selectedIncident, setSelectedIncident] = useState<Group>();
   const queryClient = useQueryClient();
@@ -157,7 +159,21 @@ const AddReportsToIncidents = ({
                     key={report._id}
                   >
                     <div className='text-sm'>
-                      <SocialMediaListItem report={report} />
+                      <SocialMediaListItem
+                        report={report}
+                        header={
+                          <span className='flex gap-1 group-hover:opacity-100 opacity-0'>
+                            <AggieButton
+                              variant='light:rose'
+                              className='rounded-lg text-xs border border-slate-300 '
+                              icon={faMinusCircle}
+                              onClick={() => addRemove(report)}
+                            >
+                              Remove from Selection
+                            </AggieButton>
+                          </span>
+                        }
+                      />
                     </div>
                   </MultiSelectListItem>
                 ))}

--- a/src/pages/Reports/components/MultiSelectActions.tsx
+++ b/src/pages/Reports/components/MultiSelectActions.tsx
@@ -17,10 +17,12 @@ import {
   faSpinner,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { hasId } from "../../../api/common";
+import { Report } from "../../../api/reports/types";
 
 interface IProps {
   disabled: boolean;
-  selection: string[];
+  selection: Report[];
   currentPageId: string | undefined;
   queryKey: string[];
 }
@@ -37,11 +39,13 @@ const MultiSelectActions = ({
 
   function onNewIncidentFromReports() {
     const params = new URLSearchParams({
-      reports: selection.join(":"),
+      reports: selection.map((i) => i._id).join(":"),
     });
 
     navigate({ pathname: "/incidents/new", search: params.toString() });
   }
+
+  const idList = selection.map((i) => i._id);
 
   return (
     <>
@@ -53,7 +57,7 @@ const MultiSelectActions = ({
           icon={faEnvelopeOpen}
           onClick={() =>
             setRead.mutate({
-              reportIds: selection,
+              reportIds: idList,
               read: true,
               currentPageId,
             })
@@ -68,7 +72,7 @@ const MultiSelectActions = ({
           icon={faEnvelope}
           onClick={() =>
             setRead.mutate({
-              reportIds: selection,
+              reportIds: idList,
               read: false,
               currentPageId,
             })
@@ -85,7 +89,7 @@ const MultiSelectActions = ({
           icon={faXmark}
           onClick={() =>
             setIrrelevance.mutate({
-              reportIds: selection,
+              reportIds: idList,
               irrelevant: "true",
               currentPageId,
             })
@@ -100,7 +104,7 @@ const MultiSelectActions = ({
           icon={faDotCircle}
           onClick={() =>
             setIrrelevance.mutate({
-              reportIds: selection,
+              reportIds: idList,
               irrelevant: "false",
               currentPageId,
             })

--- a/src/pages/Reports/components/MultiSelectActions.tsx
+++ b/src/pages/Reports/components/MultiSelectActions.tsx
@@ -117,7 +117,7 @@ const MultiSelectActions = ({
           disabled={disabled}
         >
           <FontAwesomeIcon icon={faPlus} />
-          Attach Incident
+          Add to Incident
         </AggieButton>
         <DropdownMenu
           variant='secondary'

--- a/src/pages/Reports/components/MultiSelectActions.tsx
+++ b/src/pages/Reports/components/MultiSelectActions.tsx
@@ -17,7 +17,6 @@ import {
   faSpinner,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { hasId } from "../../../api/common";
 import { Report } from "../../../api/reports/types";
 
 interface IProps {
@@ -25,6 +24,7 @@ interface IProps {
   selection: Report[];
   currentPageId: string | undefined;
   queryKey: string[];
+  addRemoveSelection: (r: Report) => void;
 }
 
 const MultiSelectActions = ({
@@ -32,6 +32,7 @@ const MultiSelectActions = ({
   selection,
   currentPageId,
   queryKey,
+  addRemoveSelection,
 }: IProps) => {
   const { setRead, setIrrelevance } = useReportMutations({ key: queryKey });
   const navigate = useNavigate();
@@ -154,6 +155,7 @@ const MultiSelectActions = ({
         selection={selection}
         queryKey={queryKey}
         isOpen={addReportModal}
+        addRemove={addRemoveSelection}
         onClose={() => {
           setAddReportModal(false);
         }}

--- a/src/pages/Reports/components/ReportHelpers.ts
+++ b/src/pages/Reports/components/ReportHelpers.ts
@@ -8,27 +8,3 @@ export const reportAuthorUrl = (report: Report) => {
     return "https://twitter.com/" + report.author;
   }
 };
-
-/**
- * This function returns the full text content of a social media post.
- * @param report to return the full text of
- * @returns fullText of the social media post
- */
-export const reportFullContent = (report: Report): string => {
-  if (report.metadata && report.metadata.rawAPIResponse) {
-    if (report.metadata.rawAPIResponse.extended_tweet) {
-      return report.metadata.rawAPIResponse.extended_tweet.full_text;
-    } else if (report.metadata.rawAPIResponse.retweeted_status) {
-      if (report.metadata.rawAPIResponse.retweeted_status.extended_tweet) {
-        if (
-          report.metadata.rawAPIResponse.retweeted_status.extended_tweet
-            .full_text
-        ) {
-          return report.metadata.rawAPIResponse.retweeted_status.extended_tweet
-            .full_text;
-        }
-      }
-    }
-  }
-  return report.content;
-};

--- a/src/pages/Reports/components/ReportListItem.tsx
+++ b/src/pages/Reports/components/ReportListItem.tsx
@@ -220,7 +220,7 @@ const ReportListItem = ({
         )}
       </div>
       <AddReportsToIncidents
-        selection={[report._id]}
+        selection={[report]}
         isOpen={openAttachModal}
         queryKey={["reports"]}
         onClose={() => setOpenAttachModal(false)}

--- a/src/pages/Reports/components/ReportListItem.tsx
+++ b/src/pages/Reports/components/ReportListItem.tsx
@@ -77,8 +77,8 @@ const ReportListItem = ({
     if (isChecked && !isSelectMode)
       return "border-2 border-slate-300 bg-slate-100 rounded-lg ";
     else if (isChecked && isSelectMode) return "bg-blue-100 ";
-    else if (report.read) return "bg-slate-100 hover:bg-slate-50 ";
-    return "bg-white hover:bg-slate-50";
+    else if (report.read) return "bg-slate-50 hover:bg-slate-100 ";
+    return "bg-white hover:bg-slate-100";
   }
 
   function onAttachedReportClick(

--- a/src/pages/Reports/components/ReportListItem.tsx
+++ b/src/pages/Reports/components/ReportListItem.tsx
@@ -6,11 +6,8 @@ import { useParams } from "react-router-dom";
 import { Report, ReportQueryState } from "../../../api/reports/types";
 import { getGroup } from "../../../api/groups";
 
-import AggieCheck from "../../../components/AggieCheck";
-
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
-  faCheck,
   faDotCircle,
   faEnvelope,
   faEnvelopeOpen,
@@ -92,16 +89,17 @@ const ReportListItem = ({
           }`}
         >
           <SocialMediaListItem
+            headerClassName='max-w-[35em]'
             report={report}
             header={
               <>
                 <div className='text-xs group-hover:opacity-0'>
                   <DateTime dateString={report.authoredAt} />
                 </div>
-                <div className='flex absolute right-0 top-0 text-xs shadow-md rounded-lg border border-slate-300 group-hover:opacity-100 opacity-0'>
+                <div className='flex gap-1 absolute right-0 top-0 text-xs group-hover:opacity-100 opacity-0'>
                   <AggieButton
                     variant={report.read ? "light:lime" : "light:amber"}
-                    className='rounded-l-lg'
+                    className='rounded-lg border border-slate-300 shadow-md'
                     onClick={(e) => {
                       e.stopPropagation();
 
@@ -117,32 +115,42 @@ const ReportListItem = ({
                   >
                     {report.read ? <> unread</> : <> read</>}
                   </AggieButton>
-                  <AggieButton
-                    variant={
-                      report.irrelevant === "true"
-                        ? "light:green"
-                        : "light:rose"
-                    }
-                    className='rounded-r-lg'
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setIrrelevance.mutate({
-                        reportIds: [report._id],
-                        irrelevant:
-                          report.irrelevant === "true" ? "false" : "true",
-                        currentPageId: currentPageId,
-                      });
-                    }}
-                    icon={report.irrelevant === "true" ? faDotCircle : faXmark}
-                    loading={setIrrelevance.isLoading}
-                    disabled={!report || setIrrelevance.isLoading}
-                  >
-                    {report.irrelevant === "true" ? (
-                      <>relevant</>
-                    ) : (
-                      <>irrelevant</>
-                    )}
-                  </AggieButton>
+                  <div className='shadow-md rounded-lg border border-slate-300 '>
+                    <AggieButton
+                      variant={"light:rose"}
+                      className='rounded-l-lg'
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setIrrelevance.mutate({
+                          reportIds: [report._id],
+                          irrelevant: "false",
+                          currentPageId: currentPageId,
+                        });
+                      }}
+                      icon={faXmark}
+                      loading={setIrrelevance.isLoading}
+                      disabled={!report || setIrrelevance.isLoading}
+                    >
+                      irrelevant
+                    </AggieButton>
+                    <AggieButton
+                      variant={"light:green"}
+                      className='rounded-r-lg'
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setIrrelevance.mutate({
+                          reportIds: [report._id],
+                          irrelevant: "true",
+                          currentPageId: currentPageId,
+                        });
+                      }}
+                      icon={faDotCircle}
+                      loading={setIrrelevance.isLoading}
+                      disabled={!report || setIrrelevance.isLoading}
+                    >
+                      relevant
+                    </AggieButton>
+                  </div>
                 </div>
               </>
             }
@@ -150,9 +158,6 @@ const ReportListItem = ({
         </div>
 
         <div className='flex flex-col '>
-          {/* <div className='flex gap-1 opacity-0 group-hover:opacity-100'>
-      <AggieButton>test</AggieButton>
-    </div> */}
           {!!report._group && !!incident ? (
             <div
               className='rounded-lg text-slate-500 bg-slate-50 px-2 py-1 flex-grow border border-slate-300 hover:cursor-pointer hover:bg-white'
@@ -196,6 +201,7 @@ const ReportListItem = ({
           isOpen={openAttachModal}
           queryKey={["reports"]}
           onClose={() => setOpenAttachModal(false)}
+          addRemove={() => setOpenAttachModal(false)}
         />
       </div>
     </MultiSelectListItem>

--- a/src/pages/Reports/components/ReportListItem.tsx
+++ b/src/pages/Reports/components/ReportListItem.tsx
@@ -123,7 +123,7 @@ const ReportListItem = ({
                         e.stopPropagation();
                         setIrrelevance.mutate({
                           reportIds: [report._id],
-                          irrelevant: "false",
+                          irrelevant: "true",
                           currentPageId: currentPageId,
                         });
                       }}
@@ -140,7 +140,7 @@ const ReportListItem = ({
                         e.stopPropagation();
                         setIrrelevance.mutate({
                           reportIds: [report._id],
-                          irrelevant: "true",
+                          irrelevant: "false",
                           currentPageId: currentPageId,
                         });
                       }}

--- a/src/pages/Reports/components/ReportsFilters.tsx
+++ b/src/pages/Reports/components/ReportsFilters.tsx
@@ -12,12 +12,13 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSearch, faXmarkSquare } from "@fortawesome/free-solid-svg-icons";
 import AggieButton from "../../../components/AggieButton";
 import Pagination from "../../../components/Pagination";
-import { getAllGroups, getGroups } from "../../../api/groups";
+import { getAllGroups } from "../../../api/groups";
 import { useCallback } from "react";
+import FilterRadioGroup from "../../../components/filters/FilterRadioGroup";
 
 interface IReportFilters {
   reportCount?: number;
-  headerElement: React.ReactElement;
+  headerElement?: React.ReactElement;
 }
 
 const ReportFilters = ({ reportCount, headerElement }: IReportFilters) => {
@@ -99,7 +100,21 @@ const ReportFilters = ({ reportCount, headerElement }: IReportFilters) => {
         </div>
       </div>
       <div className='flex justify-between text-sm'>
-        <div className='flex gap-2'>{headerElement}</div>
+        <div className='flex gap-2 items-center'>
+          {headerElement}
+          <FilterRadioGroup
+            options={{
+              false: "Relevant",
+              true: "Irrelevant",
+              all: "All",
+            }}
+            value={getParam("irrelevant")}
+            defaultValue={"false"}
+            onChange={(e) =>
+              setParams({ irrelevant: e === "false" ? undefined : e })
+            }
+          />
+        </div>
         <div className='flex items-center gap-1'>
           <FilterListbox
             label='Platforms'

--- a/src/pages/Reports/components/ReportsFilters.tsx
+++ b/src/pages/Reports/components/ReportsFilters.tsx
@@ -104,7 +104,7 @@ const ReportFilters = ({ reportCount, headerElement }: IReportFilters) => {
           {headerElement}
           <FilterRadioGroup
             options={{
-              false: "Relevant",
+              false: "Relevant/Unmarked",
               true: "Irrelevant",
               all: "All",
             }}

--- a/src/pages/Reports/useReportMutations.ts
+++ b/src/pages/Reports/useReportMutations.ts
@@ -17,12 +17,15 @@ import type {
   ReportQueryState,
 } from "../../api/reports/types";
 
-const defaultOptions = {
+interface IOptions {
+  key: any[];
+}
+const defaultOptions: IOptions = {
   key: ["reports"],
 };
 
 export const useReportMutations = (
-  userOptions: Partial<typeof defaultOptions> = defaultOptions
+  userOptions: Partial<IOptions> = defaultOptions
 ) => {
   const queryData = useUpdateQueryData();
   const navigate = useNavigate();

--- a/src/pages/Settings/user/CreateEditUserForm.tsx
+++ b/src/pages/Settings/user/CreateEditUserForm.tsx
@@ -12,7 +12,8 @@ import AggieButton from "../../../components/AggieButton";
 const userEditSchema = Yup.object().shape({
   username: Yup.string()
     .required("Username is required")
-    .min(8, "Username should be atleast 8 characters long."),
+    .min(6, "Username should be atleast 6 characters long."),
+  displayName: Yup.string(),
   role: Yup.mixed()
     .required("User Role is required")
     .oneOf([...USER_ROLES], "Invalid user role."),
@@ -26,7 +27,8 @@ type editSchema = Yup.InferType<typeof userEditSchema>;
 const userCreateSchema = Yup.object().shape({
   username: Yup.string()
     .required("Username is required")
-    .min(8, "Username should be atleast 8 characters long."),
+    .min(6, "Username should be atleast 6 characters long."),
+  displayName: Yup.string(),
   role: Yup.mixed()
     .oneOf([...USER_ROLES], "Invalid user role.")
     .required("User Role is required")
@@ -104,6 +106,11 @@ const CreateEditUserForm = ({ user, onClose }: IProps) => {
           })}
         />
         <FormikInput label='Username' name='username' />
+        <FormikInput
+          label='Display Name'
+          name='displayName'
+          placeholder='(optional) display name'
+        />
         <FormikInput label='Email' name='email' type='email' />
         {!user && (
           <>

--- a/src/pages/Settings/user/UserProfile.tsx
+++ b/src/pages/Settings/user/UserProfile.tsx
@@ -73,7 +73,14 @@ const UserProfile = ({ session }: IProps) => {
             </DropdownMenu>
           )}
         </div>
-
+        <PlaceholderDiv loading={isLoading} className={grid}>
+          <p className=''>Display Name</p>
+          <p
+            className={`text-1xl font-medium inline-flex items-center gap-1 ${grid}`}
+          >
+            {data?.displayName || "Not Set"}
+          </p>
+        </PlaceholderDiv>
         <PlaceholderDiv loading={isLoading} className={grid}>
           <p className=''>Username</p>
           <p

--- a/src/pages/incidents/Incident/Comment.tsx
+++ b/src/pages/incidents/Incident/Comment.tsx
@@ -28,11 +28,10 @@ interface IProps {
 }
 const Comment = ({ data, groupId }: IProps) => {
   const queryClient = useQueryClient();
-  const [edit, setEdit] = useState(false);
   const { data: session } = useQuery(["session"], getSession, {
     staleTime: 50000,
   });
-  if (!groupId) return <></>;
+  const [edit, setEdit] = useState(false);
 
   const doDeleteComment = useMutation(removeComment, {
     onSuccess() {
@@ -44,7 +43,6 @@ const Comment = ({ data, groupId }: IProps) => {
       queryClient.invalidateQueries(["group", groupId]);
     },
   });
-
   function onEditSubmit(
     formData: { commentdata: string },
     resetForm: () => void
@@ -63,6 +61,8 @@ const Comment = ({ data, groupId }: IProps) => {
       }
     );
   }
+  if (!groupId) return <></>;
+
   return (
     <div
       key={data._id}

--- a/src/pages/incidents/Incident/Comment.tsx
+++ b/src/pages/incidents/Incident/Comment.tsx
@@ -24,23 +24,24 @@ const CommentSchema = Yup.object().shape({
 
 interface IProps {
   data: GroupComment;
-  groupdId: string | undefined;
+  groupId: string | undefined;
 }
-const Comment = ({ data, groupdId }: IProps) => {
+const Comment = ({ data, groupId }: IProps) => {
   const queryClient = useQueryClient();
   const [edit, setEdit] = useState(false);
   const { data: session } = useQuery(["session"], getSession, {
     staleTime: 50000,
   });
+  if (!groupId) return <></>;
 
   const doDeleteComment = useMutation(removeComment, {
     onSuccess() {
-      queryClient.invalidateQueries(["group", groupdId]);
+      queryClient.invalidateQueries(["group", groupId]);
     },
   });
   const doUpdateComment = useMutation(editComment, {
     onSuccess() {
-      queryClient.invalidateQueries(["group", groupdId]);
+      queryClient.invalidateQueries(["group", groupId]);
     },
   });
 
@@ -50,19 +51,18 @@ const Comment = ({ data, groupdId }: IProps) => {
   ) {
     doUpdateComment.mutate(
       {
-        id: groupdId,
+        id: groupId,
         comment: { ...data, data: formData.commentdata },
       },
       {
         onSuccess: () => {
           resetForm();
           setEdit(false);
-          queryClient.invalidateQueries(["group", groupdId]);
+          queryClient.invalidateQueries(["group", groupId]);
         },
       }
     );
   }
-  if (!groupdId) return <></>;
   return (
     <div
       key={data._id}
@@ -96,7 +96,7 @@ const Comment = ({ data, groupdId }: IProps) => {
                 <AggieButton
                   className='w-full px-2 py-1 hover:bg-red-100  font-medium flex gap-2 text-nowrap items-center flex-grow text-red-800 '
                   onClick={() =>
-                    doDeleteComment.mutate({ id: groupdId, comment: data })
+                    doDeleteComment.mutate({ id: groupId, comment: data })
                   }
                 >
                   <FontAwesomeIcon icon={faEdit} />

--- a/src/pages/incidents/Incident/CommentTimeline.tsx
+++ b/src/pages/incidents/Incident/CommentTimeline.tsx
@@ -1,0 +1,117 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Formik, Field, Form } from "formik";
+import * as Yup from "yup";
+
+import { addComment } from "../../../api/groups";
+import {
+  EditableGroupComment,
+  Group,
+  GroupComment,
+} from "../../../api/groups/types";
+import { getSession } from "../../../api/session";
+
+import AggieButton from "../../../components/AggieButton";
+import DateTime from "../../../components/DateTime";
+import UserToken from "../../../components/UserToken";
+import Comment from "./Comment";
+
+import { faDotCircle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+interface IProps {
+  group?: Group;
+  isLoading: boolean;
+}
+const CommentTimeline = ({ group, isLoading }: IProps) => {
+  const queryClient = useQueryClient();
+
+  if (!group) return <></>;
+
+  const postNewComment = useMutation(addComment);
+
+  const { data: session } = useQuery(["session"], getSession, {
+    staleTime: 50000,
+  });
+  function onPostAdd(formData: { commentdata: string }, resetForm: () => void) {
+    if (!session || !group) return false;
+    const post: EditableGroupComment = {
+      data: formData.commentdata,
+      author: session._id,
+    };
+    postNewComment.mutate(
+      { id: group._id, comment: post },
+      {
+        onSuccess: () => {
+          resetForm();
+          queryClient.invalidateQueries(["group", group._id]);
+        },
+      }
+    );
+  }
+
+  return (
+    <article className='mt-4'>
+      <div className='px-2 py-2 flex justify-between'>
+        <h2 className='text-sm font-medium flex gap-1 items-center'>
+          <FontAwesomeIcon icon={faDotCircle} className='text-slate-600 mr-1' />
+          <span className='font-normal italic text-slate-600'> user </span>
+          <UserToken id={group?.creator?._id || ""} loading={isLoading} />
+          <span className='font-normal italic text-slate-600'>
+            {" "}
+            created this incident on
+          </span>{" "}
+          <span>
+            {" "}
+            <DateTime dateString={group?.storedAt || ""} />
+          </span>
+        </h2>
+        <p></p>
+      </div>
+      <div>
+        {!!group?.comments &&
+          group.comments.map((comment: GroupComment) => (
+            <Comment data={comment} groupId={group._id} key={comment._id} />
+          ))}
+      </div>
+      <div className=' bg-slate-50 border border-slate-300 rounded-lg'>
+        <h2 className='font-medium ml-3 my-2'>Add Comment</h2>
+        <Formik
+          initialValues={{ commentdata: "" }}
+          onSubmit={(e, { resetForm }) => {
+            onPostAdd(e, resetForm);
+          }}
+          validationSchema={Yup.object().shape({
+            commentdata: Yup.string().required("Cannot Post Empty Comment!"),
+          })}
+        >
+          {({ resetForm, errors }) => (
+            <Form>
+              <Field
+                as='textarea'
+                name='commentdata'
+                className='focus-theme px-3 py-1 border-y border-slate-300 bg-white w-full min-h-36'
+                placeholder='Write a comment here...'
+              />
+              {errors && (
+                <p className='text-sm text-rose-700 italic ml-2'>
+                  {errors.commentdata}
+                </p>
+              )}
+
+              <AggieButton
+                type='submit'
+                variant='primary'
+                className='mb-2 ml-2 mt-1'
+                loading={postNewComment.isLoading}
+                disabled={postNewComment.isLoading}
+              >
+                Post
+              </AggieButton>
+            </Form>
+          )}
+        </Formik>
+      </div>
+    </article>
+  );
+};
+export default CommentTimeline;

--- a/src/pages/incidents/Incident/CommentTimeline.tsx
+++ b/src/pages/incidents/Incident/CommentTimeline.tsx
@@ -25,8 +25,6 @@ interface IProps {
 const CommentTimeline = ({ group, isLoading }: IProps) => {
   const queryClient = useQueryClient();
 
-  if (!group) return <></>;
-
   const postNewComment = useMutation(addComment);
 
   const { data: session } = useQuery(["session"], getSession, {
@@ -48,6 +46,7 @@ const CommentTimeline = ({ group, isLoading }: IProps) => {
       }
     );
   }
+  if (!group) return <></>;
 
   return (
     <article className='mt-4'>

--- a/src/pages/incidents/Incident/GoupReportListItem.tsx
+++ b/src/pages/incidents/Incident/GoupReportListItem.tsx
@@ -2,6 +2,7 @@ import { faCheck } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Report } from "../../../api/reports/types";
 import AggieCheck from "../../../components/AggieCheck";
+import MultiSelectListItem from "../../../components/MultiSelectListItem";
 import SocialMediaListItem from "../../../components/SocialMediaListItem";
 
 interface IProps {
@@ -17,46 +18,16 @@ const GroupReportListItem = ({
   isSelectMode,
   onCheckChange,
 }: IProps) => {
-  function onChange(e: React.MouseEvent<HTMLDivElement>) {
-    e.stopPropagation();
-    onCheckChange();
-  }
-  // refactor at some point
-  function bgState() {
-    if (isChecked && !isSelectMode)
-      return "border-2 border-slate-300 bg-slate-100 rounded-lg ";
-    else if (isChecked && isSelectMode) return "bg-blue-100 ";
-    return "bg-white hover:bg-slate-100";
-  }
   return (
-    <article
-      className={`px-2 py-3 pb-4 border-b border-slate-300 ${bgState()} relative group`}
+    <MultiSelectListItem
+      isChecked={isChecked}
+      isSelectMode={isSelectMode}
+      onCheckChange={onCheckChange}
     >
-      <div className={`col-span-4 pl-8  `}>
-        {isSelectMode ? (
-          <div
-            className='flex items-center absolute top-0 bottom-0 left-0 w-12 pointer-events-none '
-            onClick={onChange}
-          >
-            <div className='w-full h-full pointer-events-auto cursor-pointer group hover:bg-blue-200/25 rounded p-2 pl-3 '>
-              <div
-                className={`w-4 h-4  border border-slate-500  group-hover:border-slate-600 grid place-items-center rounded ${
-                  isChecked ? "bg-blue-500 text-slate-50" : "bg-white"
-                }`}
-              >
-                {isChecked && <FontAwesomeIcon icon={faCheck} size='xs' />}
-              </div>
-            </div>
-            <div className='absolute ml-8 pointer-events-none h-full my-3 border-r border-slate-300'></div>
-          </div>
-        ) : (
-          <div className='opacity-0 group-hover:opacity-100 flex items-center absolute top-0 left-0 pointer-events-none p-2 pl-3 '>
-            <AggieCheck active={isChecked} onClick={onChange} />
-          </div>
-        )}
+      <div className='text-sm'>
         <SocialMediaListItem report={report} />
       </div>
-    </article>
+    </MultiSelectListItem>
   );
 };
 

--- a/src/pages/incidents/Incident/GoupReportListItem.tsx
+++ b/src/pages/incidents/Incident/GoupReportListItem.tsx
@@ -26,36 +26,41 @@ const GroupReportListItem = ({
     if (isChecked && !isSelectMode)
       return "border-2 border-slate-300 bg-slate-100 rounded-lg ";
     else if (isChecked && isSelectMode) return "bg-blue-100 ";
-    else if (report.read) return "bg-slate-100 hover:bg-slate-50 ";
-    return "bg-white hover:bg-slate-50";
+    else if (report.read) return "bg-slate-50 hover:bg-slate-100 ";
+    return "bg-white hover:bg-slate-100";
   }
-
   return (
     <article
-      className={`px-2 pl-7 py-2 pb-4 border-b ${bgState()} relative group`}
+      className={`px-2 py-3 pb-4 border-b border-slate-300 ${bgState()} relative group`}
     >
-      {isSelectMode ? (
-        <div
-          className='flex items-center absolute top-0 bottom-0 left-0 w-12 pointer-events-none '
-          onClick={onChange}
-        >
-          <div className='w-full h-full pointer-events-auto cursor-pointer group hover:bg-blue-200/25 rounded p-2 pl-3 '>
-            <div
-              className={`w-4 h-4  border border-slate-500  group-hover:border-slate-600 grid place-items-center rounded ${
-                isChecked ? "bg-blue-500 text-slate-50" : "bg-white"
-              }`}
-            >
-              {isChecked && <FontAwesomeIcon icon={faCheck} size='xs' />}
+      <div
+        className={`col-span-4 pl-7  ${
+          report.read ? "" : " border-l-2 border-blue-600 "
+        }`}
+      >
+        {isSelectMode ? (
+          <div
+            className='flex items-center absolute top-0 bottom-0 left-0 w-12 pointer-events-none '
+            onClick={onChange}
+          >
+            <div className='w-full h-full pointer-events-auto cursor-pointer group hover:bg-blue-200/25 rounded p-2 pl-3 '>
+              <div
+                className={`w-4 h-4  border border-slate-500  group-hover:border-slate-600 grid place-items-center rounded ${
+                  isChecked ? "bg-blue-500 text-slate-50" : "bg-white"
+                }`}
+              >
+                {isChecked && <FontAwesomeIcon icon={faCheck} size='xs' />}
+              </div>
             </div>
+            <div className='absolute ml-8 pointer-events-none h-full my-3 border-r border-slate-300'></div>
           </div>
-          <div className='absolute ml-8 pointer-events-none h-full my-3 border-r border-slate-300'></div>
-        </div>
-      ) : (
-        <div className='opacity-0 group-hover:opacity-100 flex items-center absolute top-0 left-0 pointer-events-none p-2 pl-3 '>
-          <AggieCheck active={isChecked} onClick={onChange} />
-        </div>
-      )}
-      <SocialMediaListItem report={report} />
+        ) : (
+          <div className='opacity-0 group-hover:opacity-100 flex items-center absolute top-0 left-0 pointer-events-none p-2 pl-3 '>
+            <AggieCheck active={isChecked} onClick={onChange} />
+          </div>
+        )}
+        <SocialMediaListItem report={report} />
+      </div>
     </article>
   );
 };

--- a/src/pages/incidents/Incident/GoupReportListItem.tsx
+++ b/src/pages/incidents/Incident/GoupReportListItem.tsx
@@ -1,0 +1,63 @@
+import { faCheck } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Report } from "../../../api/reports/types";
+import AggieCheck from "../../../components/AggieCheck";
+import SocialMediaListItem from "../../../components/SocialMediaListItem";
+
+interface IProps {
+  report: Report;
+  isChecked: boolean;
+  isSelectMode: boolean;
+  onCheckChange: () => void;
+}
+
+const GroupReportListItem = ({
+  report,
+  isChecked,
+  isSelectMode,
+  onCheckChange,
+}: IProps) => {
+  function onChange(e: React.MouseEvent<HTMLDivElement>) {
+    e.stopPropagation();
+    onCheckChange();
+  }
+  // refactor at some point
+  function bgState() {
+    if (isChecked && !isSelectMode)
+      return "border-2 border-slate-300 bg-slate-100 rounded-lg ";
+    else if (isChecked && isSelectMode) return "bg-blue-100 ";
+    else if (report.read) return "bg-slate-100 hover:bg-slate-50 ";
+    return "bg-white hover:bg-slate-50";
+  }
+
+  return (
+    <article
+      className={`px-2 pl-7 py-2 pb-4 border-b ${bgState()} relative group`}
+    >
+      {isSelectMode ? (
+        <div
+          className='flex items-center absolute top-0 bottom-0 left-0 w-12 pointer-events-none '
+          onClick={onChange}
+        >
+          <div className='w-full h-full pointer-events-auto cursor-pointer group hover:bg-blue-200/25 rounded p-2 pl-3 '>
+            <div
+              className={`w-4 h-4  border border-slate-500  group-hover:border-slate-600 grid place-items-center rounded ${
+                isChecked ? "bg-blue-500 text-slate-50" : "bg-white"
+              }`}
+            >
+              {isChecked && <FontAwesomeIcon icon={faCheck} size='xs' />}
+            </div>
+          </div>
+          <div className='absolute ml-8 pointer-events-none h-full my-3 border-r border-slate-300'></div>
+        </div>
+      ) : (
+        <div className='opacity-0 group-hover:opacity-100 flex items-center absolute top-0 left-0 pointer-events-none p-2 pl-3 '>
+          <AggieCheck active={isChecked} onClick={onChange} />
+        </div>
+      )}
+      <SocialMediaListItem report={report} />
+    </article>
+  );
+};
+
+export default GroupReportListItem;

--- a/src/pages/incidents/Incident/GoupReportListItem.tsx
+++ b/src/pages/incidents/Incident/GoupReportListItem.tsx
@@ -26,18 +26,13 @@ const GroupReportListItem = ({
     if (isChecked && !isSelectMode)
       return "border-2 border-slate-300 bg-slate-100 rounded-lg ";
     else if (isChecked && isSelectMode) return "bg-blue-100 ";
-    else if (report.read) return "bg-slate-50 hover:bg-slate-100 ";
     return "bg-white hover:bg-slate-100";
   }
   return (
     <article
       className={`px-2 py-3 pb-4 border-b border-slate-300 ${bgState()} relative group`}
     >
-      <div
-        className={`col-span-4 pl-7  ${
-          report.read ? "" : " border-l-2 border-blue-600 "
-        }`}
-      >
+      <div className={`col-span-4 pl-8  `}>
         {isSelectMode ? (
           <div
             className='flex items-center absolute top-0 bottom-0 left-0 w-12 pointer-events-none '

--- a/src/pages/incidents/Incident/IncidentInfo.tsx
+++ b/src/pages/incidents/Incident/IncidentInfo.tsx
@@ -1,0 +1,105 @@
+import { faMinusCircle, faWarning } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Group } from "../../../api/groups/types";
+import AggieButton from "../../../components/AggieButton";
+import PlaceholderDiv from "../../../components/PlaceholderDiv";
+import TagsList from "../../../components/Tags/TagsList";
+import UserToken from "../../../components/UserToken";
+import VeracityToken from "../../../components/VeracityToken";
+
+interface IProps {
+  group?: Group;
+  isLoading: boolean;
+}
+const IncidentInfo = ({ group, isLoading }: IProps) => {
+  return (
+    <header className='text-slate-600 border-b border-slate-300 py-2'>
+      <div className='flex justify-between'>
+        <div>
+          <div className='flex gap-1 flex-wrap'>
+            <VeracityToken value={group?.veracity} />
+            {group?.closed && (
+              <span className='px-1 bg-purple-200 text-purple-700 font-medium inline-flex gap-1 items-center'>
+                <FontAwesomeIcon icon={faMinusCircle} />
+                Closed
+              </span>
+            )}
+            <TagsList values={group?.smtcTags} />
+          </div>
+          <PlaceholderDiv
+            loading={isLoading}
+            className='text-black text-3xl font-medium my-2'
+            loadingClass='mt-1 bg-slate-200 rounded-lg'
+            width='12em'
+          >
+            <h1>
+              {group?.title}{" "}
+              {group?.escalated && (
+                <span className='px-1 bg-orange-700 text-white font-medium text-base inline-flex gap-1 items-center no-underline'>
+                  <FontAwesomeIcon icon={faWarning} />
+                  Escalated
+                </span>
+              )}
+            </h1>
+          </PlaceholderDiv>
+        </div>
+      </div>
+      <div className='flex gap-12 my-2'>
+        <PlaceholderDiv as='p' width='7em' loading={isLoading}>
+          Id #{group?.idnum}
+        </PlaceholderDiv>
+        <PlaceholderDiv as='p' width='7em' loading={isLoading}>
+          <span className='font-medium'>{group?._reports.length}</span> reports
+          attached
+        </PlaceholderDiv>
+
+        <PlaceholderDiv as='p' width='7em' loading={isLoading}>
+          {group?.locationName && (
+            <>
+              located at{" "}
+              <span className='font-medium'>{group?.locationName}</span>
+            </>
+          )}
+        </PlaceholderDiv>
+        <PlaceholderDiv as='p' width='7em' loading={isLoading}>
+          created by{" "}
+          <span className='font-medium'>{group?.creator?.username}</span>
+        </PlaceholderDiv>
+      </div>
+      <div className='border-t border-slate-300 flex gap-2 items-center py-2'>
+        <span className='whitespace-nowrap'>Assigned To:</span>
+        <PlaceholderDiv
+          loading={isLoading}
+          className='flex flex-wrap gap-x-2 gap-y-1 items-center '
+        >
+          {group?.assignedTo?.map((user) => (
+            <UserToken
+              id={user._id}
+              className='bg-white border border-slate-300 rounded-full px-2 text-sm font-medium'
+            />
+          ))}
+          <AggieButton
+            className='hover:underline text-blue-600 text-sm '
+            onClick={() => console.log()}
+          >
+            Change
+          </AggieButton>
+        </PlaceholderDiv>
+      </div>
+
+      <div className='flex gap-2'>
+        <p>Description:</p>
+
+        {group?.notes ? (
+          <div className='px-2 py-1 border border-slate-200 rounded w-full bg-white overflow-y-auto max-h-40'>
+            <p className='whitespace-pre-line max-w-prose '>{group?.notes}</p>
+          </div>
+        ) : (
+          <p className='italic text-slate-600'>No Description Set</p>
+        )}
+      </div>
+    </header>
+  );
+};
+
+export default IncidentInfo;

--- a/src/pages/incidents/Incident/IncidentInfo.tsx
+++ b/src/pages/incidents/Incident/IncidentInfo.tsx
@@ -10,8 +10,9 @@ import VeracityToken from "../../../components/VeracityToken";
 interface IProps {
   group?: Group;
   isLoading: boolean;
+  onEdit: () => void;
 }
-const IncidentInfo = ({ group, isLoading }: IProps) => {
+const IncidentInfo = ({ group, isLoading, onEdit }: IProps) => {
   return (
     <header className='text-slate-600 border-b border-slate-300 py-2'>
       <div className='flex justify-between'>
@@ -79,8 +80,8 @@ const IncidentInfo = ({ group, isLoading }: IProps) => {
             />
           ))}
           <AggieButton
-            className='hover:underline text-blue-600 text-sm '
-            onClick={() => console.log()}
+            className='hover:underline text-blue-600 text-xs '
+            onClick={() => onEdit()}
           >
             Change
           </AggieButton>

--- a/src/pages/incidents/Incident/index.tsx
+++ b/src/pages/incidents/Incident/index.tsx
@@ -223,7 +223,11 @@ const Incident = () => {
             </DropdownMenu>
           </div>
         </div>
-        <IncidentInfo group={group} isLoading={isLoading} />
+        <IncidentInfo
+          group={group}
+          isLoading={isLoading}
+          onEdit={() => setIsEditOpen(true)}
+        />
 
         <CommentTimeline group={group} isLoading={isLoading} />
       </main>

--- a/src/pages/incidents/Incident/index.tsx
+++ b/src/pages/incidents/Incident/index.tsx
@@ -104,6 +104,7 @@ const Incident = () => {
     <section className='max-w-screen-2xl mx-auto px-4 grid grid-cols-2 pt-6 gap-6 '>
       <AddReportsToIncidents
         selection={multiSelect.selection}
+        addRemove={multiSelect.addRemove}
         isOpen={addReportModal}
         queryKey={["groups", "reports", { groupId: id }]}
         onClose={() => setAddReportModal(false)}

--- a/src/pages/incidents/IncidentListItem.tsx
+++ b/src/pages/incidents/IncidentListItem.tsx
@@ -63,8 +63,8 @@ const IncidentListItem = ({ item }: IProps) => {
   }
 
   return (
-    <article className='group relative grid grid-cols-4 lg:grid-cols-6 p-3 text-sm text-slate-600 border-b border-slate-300'>
-      <div className='absolute top-0 left-0 bottom-0 right-[15%] z-20'>
+    <article className='group relative grid grid-cols-4 lg:grid-cols-6 p-3 text-sm text-slate-600 border-b border-slate-300 z-0'>
+      <div className='absolute top-0 left-0 bottom-0 right-[15%] z-10'>
         <button
           onClick={onOpenIncidentPage}
           title={`open incident ${item.title}`}


### PR DESCRIPTION
reports in other pages are now in list format for faster scans
- incidents page has filters and click to view post previews
- multi select to move posts or mark as irrelevant
- refactoring part 1.

"add reports to incident" modal
- reports are now in lists

misc
- refactor multi-select to fix #45 
- new multi-select list item component for consistent multi select 
- quotes and quote retweets view in report list
- sticky navbar 
- pagination now uses popover